### PR TITLE
Fix for TRANSREL-24

### DIFF
--- a/web-app/Rscripts/ANOVA/BuildANOVAData.R
+++ b/web-app/Rscripts/ANOVA/BuildANOVAData.R
@@ -194,7 +194,9 @@ gpl.independent= ''
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	##########################################
 	
 	print("-------------------")

--- a/web-app/Rscripts/Correlation/BuildCorrelationData.R
+++ b/web-app/Rscripts/Correlation/BuildCorrelationData.R
@@ -62,5 +62,7 @@ correlation.by = ""
 	require(MASS)
 	
 	#Write the final data file.
-	write.matrix(finalData,"outputfile.txt",sep = "\t")
+	# write.matrix(finalData,"outputfile.txt",sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 }

--- a/web-app/Rscripts/ForestPlot/BuildForestPlotData.R
+++ b/web-app/Rscripts/ForestPlot/BuildForestPlotData.R
@@ -375,7 +375,9 @@ snptype.Reference = ''
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/Heatmap/BuildHeatmapData.R
+++ b/web-app/Rscripts/Heatmap/BuildHeatmapData.R
@@ -77,9 +77,12 @@ output.dataFile="outputfile"
 	
 	#We need MASS to dump the matrix to a file.
 	require(MASS)	
-	
+
+	finalData <- geneExpressionMatrix
 	#Write the final data file.
-	write.matrix(geneExpressionMatrix,output.dataFile,sep = "\t")
+	# write.matrix(geneExpressionMatrix,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/IC50/BuildIC50Data.R
+++ b/web-app/Rscripts/IC50/BuildIC50Data.R
@@ -89,7 +89,9 @@ function
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/LogisticRegression/BuildLogisticRegressionData.R
+++ b/web-app/Rscripts/LogisticRegression/BuildLogisticRegressionData.R
@@ -177,7 +177,9 @@ gpl.independent= ''
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	##########################################
 	
 	print("-------------------")

--- a/web-app/Rscripts/MarkerSelection/BuildMSData.R
+++ b/web-app/Rscripts/MarkerSelection/BuildMSData.R
@@ -71,7 +71,9 @@ output.dataFile="outputfile"
 	require(MASS)	
 	
 	#Write the final data file.
-	write.matrix(finalFrame,output.dataFile,sep = "\t")
-	print("-------------------")
+	#write.matrix(finalFrame,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
+    print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/PCA/BuildPCAData.R
+++ b/web-app/Rscripts/PCA/BuildPCAData.R
@@ -70,7 +70,9 @@ output.dataFile="outputfile"
 	require(MASS)	
 	
 	#Write the final data file.
-	write.matrix(finalFrame,output.dataFile,sep = "\t")
-	print("-------------------")
+	#write.matrix(finalFrame,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
+    print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/ScatterPlot/BuildScatterData.R
+++ b/web-app/Rscripts/ScatterPlot/BuildScatterData.R
@@ -131,7 +131,9 @@ logX=''
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
-	print("-------------------")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
+    print("-------------------")
 	##########################################
 }

--- a/web-app/Rscripts/Survival/BuildSurvivalData.R
+++ b/web-app/Rscripts/Survival/BuildSurvivalData.R
@@ -149,6 +149,8 @@ snptype.category = ''
 	require(MASS)
 	
 	#Write the final data file.
-	write.matrix(finalData,"outputfile",sep = "\t")
-	print("-------------------")
+	#write.matrix(finalData,"outputfile",sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
+    print("-------------------")
 }

--- a/web-app/Rscripts/TableWithFisher/BuildFisherData.R
+++ b/web-app/Rscripts/TableWithFisher/BuildFisherData.R
@@ -173,8 +173,10 @@ snptype.independent = ''
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(finalData,output.dataFile,sep = "\t")
-	print("-------------------")
+	#write.matrix(finalData,output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(finalData,filename, sep = "\t", quote = FALSE, row.names = FALSE)
+    print("-------------------")
 	##########################################
 }
 

--- a/web-app/Rscripts/Waterfall/BuildWaterfallData.R
+++ b/web-app/Rscripts/Waterfall/BuildWaterfallData.R
@@ -99,7 +99,9 @@ function
 	require(MASS)
 
 	#Write the final data file.
-	write.matrix(format(finalData,sci=FALSE),output.dataFile,sep = "\t")
+	#write.matrix(format(finalData,sci=FALSE),output.dataFile,sep = "\t")
+	# Using write.table; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24.
+    write.table(format(finalData,sci=FALSE),filename, sep = "\t", quote = FALSE, row.names = FALSE)
 	print("-------------------")
 	##########################################
 }


### PR DESCRIPTION
 Changed R files to write out table data for export using write.table instead of write.matrix; write.matrix was leaving trailing white-space in the file - see JIRA issue TRANSREL-24. Also see companion pull request in transmartApp.
